### PR TITLE
Switch to microseconds directly encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The package can be installed by adding `uuid_v7` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:uuid_v7, "~> 0.2.4"}
+    {:uuid_v7, "~> 0.3.0"}
   ]
 end
 ```

--- a/lib/uuidv7.ex
+++ b/lib/uuidv7.ex
@@ -40,6 +40,18 @@ defmodule UUIDv7 do
   def generate, do: bingenerate() |> encode()
 
   @doc """
+  Generates a version 7 UUID using microseconds for increased clock precision.
+
+  ## Example
+
+      iex> UUIDv7.generate()
+      "018e90d8-06e8-7f9f-bfd7-6730ba98a51b"
+
+  """
+  @spec generate(DateTime.t() | integer()) :: t
+  def generate(timestamp), do: bingenerate(timestamp) |> encode()
+
+  @doc """
   Generates a version 7 UUID in the binary format.
 
   ## Example
@@ -50,7 +62,7 @@ defmodule UUIDv7 do
   """
   @spec bingenerate() :: raw
   def bingenerate do
-    System.system_time(:microsecond) |> from_timestamp()
+    System.system_time(:microsecond) |> bingenerate()
   end
 
   @doc """
@@ -59,20 +71,20 @@ defmodule UUIDv7 do
   ## Examples
 
       iex> timestamp = System.system_time(:microsecond)
-      iex> UUIDv7.from_timestamp(timestamp)
+      iex> UUIDv7.bingenerate(timestamp)
       <<1, 142, 144, 216, 6, 232, 127, 159, 191, 215, 103, 48, 186, 152, 165, 27>>
 
       iex> timestamp = DateTime.utc_now()
-      iex> UUIDv7.from_timestamp(timestamp)
+      iex> UUIDv7.bingenerate(timestamp)
       <<1, 142, 144, 216, 6, 232, 127, 159, 191, 215, 103, 48, 186, 152, 165, 27>>
 
   """
-  @spec from_timestamp(pos_integer | DateTime.t()) :: raw
-  def from_timestamp(%DateTime{} = datetime) do
-    DateTime.to_unix(datetime, :microsecond) |> from_timestamp()
+  @spec bingenerate(pos_integer | DateTime.t()) :: raw
+  def bingenerate(%DateTime{} = datetime) do
+    DateTime.to_unix(datetime, :microsecond) |> bingenerate()
   end
 
-  def from_timestamp(time) when is_integer(time) do
+  def bingenerate(time) when is_integer(time) do
     # Replace left-most random bits (rand_a) with increased clock precision.
     # We could use up to 12 bits, but since using microseconds, we only need
     # to use 10 bits. The remaining 2, can be rand_a.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule UUIDv7.MixProject do
   use Mix.Project
 
-  @version "0.2.4"
+  @version "0.3.0"
 
   @repo_url "https://github.com/ryanwinchester/uuidv7"
 

--- a/test/uuidv7_test.exs
+++ b/test/uuidv7_test.exs
@@ -22,4 +22,10 @@ defmodule UUIDv7Test do
     assert decoded = UUIDv7.decode(uuid)
     assert ^uuid = UUIDv7.encode(decoded)
   end
+
+  test "get_timestamp/1 gets the original timestamp" do
+    assert timestamp = 1_711_827_060_456_999
+    assert uuid = UUIDv7.from_timestamp(timestamp) |> UUIDv7.encode()
+    assert UUIDv7.get_timestamp(uuid) == timestamp
+  end
 end

--- a/test/uuidv7_test.exs
+++ b/test/uuidv7_test.exs
@@ -1,14 +1,22 @@
 defmodule UUIDv7Test do
   use ExUnit.Case, async: true
 
-  doctest UUIDv7, except: [:moduledoc, generate: 0, bingenerate: 0, from_timestamp: 1]
+  doctest UUIDv7, except: [:moduledoc, generate: 0, generate: 1, bingenerate: 0, bingenerate: 1]
 
-  test "generates uuid string" do
+  test "generate/0 generates uuid string" do
     assert <<_::288>> = UUIDv7.generate()
   end
 
-  test "generates uuid binary" do
+  test "generate/1 generates uuid string" do
+    assert <<_::288>> = UUIDv7.generate(DateTime.utc_now())
+  end
+
+  test "bingenerate/0 generates uuid binary" do
     assert <<_::128>> = UUIDv7.bingenerate()
+  end
+
+  test "bingenerate/1 generates uuid binary" do
+    assert <<_::128>> = UUIDv7.bingenerate(DateTime.utc_now())
   end
 
   test "encode/1" do
@@ -25,7 +33,7 @@ defmodule UUIDv7Test do
 
   test "get_timestamp/1 gets the original timestamp" do
     assert timestamp = 1_711_827_060_456_999
-    assert uuid = UUIDv7.from_timestamp(timestamp) |> UUIDv7.encode()
+    assert uuid = UUIDv7.bingenerate(timestamp) |> UUIDv7.encode()
     assert UUIDv7.get_timestamp(uuid) == timestamp
   end
 end


### PR DESCRIPTION
Since microseconds fit directly into 10 bits I don't need to spread them out and this will be more precise, as well as allowing us to extract the original timestamp more easily (and without approximating).

Thoughts?